### PR TITLE
docs: initial template for charter #1

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,0 +1,45 @@
+# Resource Aggregation Working Group Operating Document
+
+## 1. Working Group Definition
+
+Tl;Dr: The primary of objective of this working group is… including:
+Point A
+Point B
+Point C
+
+## 2. Working Group Composition
+
+The Working Group is composed of…
+
+The membership profile is…
+
+### Roles & Responsibilities 
+
+## 3. Meetings
+
+### Cadence
+
+### Critical Annual Activities 
+
+Ex: budget/finance, meeting planning, elections, etc…
+
+## 4. Working Group Resources
+
+
+
+
+---
+All Working Groups within the DevRel Foundation must: 
+
+- Function with openness and transparency, meaning that participation is open to all, and minutes and other documents are available and easily accessible to everyone
+- Adhere to the DevRel Foundation’s Code of Conduct (link)
+- Follows Linux Foundation's [Antitrust Policy] (https://www.linuxfoundation.org/legal/antitrust-policy)
+- Follow Chatham House Rule  https://www.chathamhouse.org/about-us/chatham-house-rule 
+- and as otherwise set up in the Developer Relations Foundation Charter
+(which is as follows: 
+
+More information: https://github.com/DevRel-Foundation/governance/pull/17/files#diff-a5e748f515fc060f9baf9feb8e2871c97cd5657858b78f583c6c025c7e49f176 
+
+
+Compliance with Policies 
+This Charter is subject to the Series Agreement for the Project and the Operating Agreement of LF Projects. Contributors will comply with the policies of LF Projects as may be adopted and amended by LF Projects, including, without limitation the policies listed at https://lfprojects.org/policies/.  


### PR DESCRIPTION
This is a copy of the template from the Google Doc without any substantive content yet.

Added it as `CHARTER.md` which I noticed on another LF project as a naming convention.